### PR TITLE
add less verbose slug generator spec

### DIFF
--- a/spec/job/adapters/kubernetes/slug_generator_spec.rb
+++ b/spec/job/adapters/kubernetes/slug_generator_spec.rb
@@ -1,27 +1,21 @@
 require "ood_core/job/adapters/kubernetes/slug_generator"
 
-class TestSlugGenerator
-    extend SlugGenerator
-end
+RSpec.describe SlugGenerator do
+  describe '#safe_slug' do
+    subject { described_class.safe_slug(input) }
 
-describe TestSlugGenerator do
-
-    describe '#safe_slug' do
-
-        it "preserves names that are already valid" do
-            expect(SlugGenerator::safe_slug("jupyter-alex")).to eq("jupyter-alex")
-        end
-
-        it "converts upper case characters into lower case" do
-            expect(SlugGenerator::safe_slug("jupyter-Alex")).to eq("jupyter-alex---3a1c285c")
-        end
-
-        it "removes unicode characters" do
-            expect(SlugGenerator::safe_slug("jupyter-üni")).to eq("jupyter-ni---a5aaf5dd")
-        end
-
-        it "makes sure slug doesn't end with '-'" do
-
-        end
+    {
+      "preserves valid names" => ["jupyter-alex", "jupyter-alex"],
+      "converts uppercase to lowercase" => ["jupyter-Alex", "jupyter-alex---3a1c285c"],
+      "removes unicode characters" => ["jupyter-üni", "jupyter-ni---a5aaf5dd"]
+    }.each do |description, (input, expected)|
+      it description do
+        expect(subject).to eq(expected)
+      end
     end
+
+    it "ensures slug doesn't end with '-'" do
+      expect(described_class.safe_slug("jupyter-")).not_to end_with('-')
+    end
+  end
 end


### PR DESCRIPTION
1. Removed the `TestSlugGenerator` class, as it's not necessary. We can test `SlugGenerator` directly.
2. Used `RSpec.describe` to describe the `SlugGenerator` module directly.
3. Defined `subject` as the result of calling `safe_slug` with the `input`. This allows us to use the more concise `expect(subject)` in our tests.
4. Grouped similar tests into a hash, where the key is the description and the value is an array of `[input, expected_output]`
5. Used an iterator to create test cases for each entry in the hash. This significantly reduces repetition in the test code.
6. Kept the last test case separate, as it has a different structure. Used `not_to end_with('-')` for a more specific assertion.