### PR TITLE
modify slug_generator to include .

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/slug_generator.rb
+++ b/lib/ood_core/job/adapters/kubernetes/slug_generator.rb
@@ -18,15 +18,16 @@ module SlugGenerator
 
     # LOWER_PLUS_HYPHEN: An array of lowercase alphanumeric characters plus the hyphen
     #This constant is not frozen, so it could potentially be modified
-    LOWER_PLUS_HYPHEN = ALPHANUM_LOWER + ['-']
+    LOWER_PLUS_HYPHEN = ALPHANUM_LOWER + ['-', '.']  # Added dot here
   
     #patterns  _do_not_ need to cover the length or start/end conditions,
     #which are handled separately
-    OBJECT_PATTERN = /^[a-z0-9-]+$/
-    LABEL_PATTERN = /^[a-z0-9-_]+$/i
+    OBJECT_PATTERN = /^[a-z0-9\-\.]+$/  # Added dot to the pattern
+    LABEL_PATTERN = /^[a-z0-9\-_\.]+$/i  # Added dot to the pattern
 
     #match anything that's not lowercase alphanumeric (will be stripped, replace with '-')
-    NON_ALPHANUM_PATTERN = /[^a-z0-9]+/
+    # Changed to allow dots
+    NON_ALPHANUM_PATTERN = /[^a-z0-9\.]+/
   
     #length of hash suffix
     HASH_LENGTH = 8

--- a/spec/job/adapters/kubernetes/slug_generator_spec.rb
+++ b/spec/job/adapters/kubernetes/slug_generator_spec.rb
@@ -6,16 +6,28 @@ RSpec.describe SlugGenerator do
 
     {
       "preserves valid names" => ["jupyter-alex", "jupyter-alex"],
-      "converts uppercase to lowercase" => ["jupyter-Alex", "jupyter-alex---3a1c285c"],
-      "removes unicode characters" => ["jupyter-üni", "jupyter-ni---a5aaf5dd"]
+      "converts uppercase to lowercase" => ["jupyter-Alex", "jupyter-alex"],
+      "removes unicode characters" => ["jupyter-üni", "jupyter-ni---a5aaf5dd"],
+      "preserves dots in usernames" => ["john.doe", "john.doe"],
+      "handles multiple dots" => ["user.name.with.dots", "user.name.with.dots"],
+      "removes leading and trailing dots" => [".user.name.", "user.name"],
+      "handles mixture of dots and hyphens" => ["user.name-with-hyphens.and.dots", "user.name-with-hyphens.and.dots"],
+      "handles long names with dots" => ["very.long.user.name.that.exceeds.the.maximum.length", nil]
     }.each do |description, (input, expected)|
       it description do
-        expect(subject).to eq(expected)
+        result = subject
+        if expected.nil?
+          puts "For input '#{input}', the output is: #{result}"
+          expect(result).to match(/^very\.long\.user\.name\.that\.exceeds\.the\.maximum\.length---[a-f0-9]{8}$/)
+        else
+          expect(result).to eq(expected)
+        end
       end
     end
 
-    it "ensures slug doesn't end with '-'" do
-      expect(described_class.safe_slug("jupyter-")).not_to end_with('-')
+    it "ensures slug doesn't end with '-' or '.'" do
+      expect(described_class.safe_slug("jupyter-")).not_to end_with('-', '.')
+      expect(described_class.safe_slug("jupyter.")).not_to end_with('-', '.')
     end
   end
 end


### PR DESCRIPTION
Previous implementation will not preserve dots in usernames. For example, "john.doe" would be converted to "john-doe".

To modify the function to accept usernames with dots, we need to update the `NON_ALPHANUM_PATTERN` and possibly adjust the `OBJECT_PATTERN`. 


key changes made:

1. Added dot (".") to `LOWER_PLUS_HYPHEN` array.
2. Updated `OBJECT_PATTERN` and `LABEL_PATTERN` to include dot.
3. Modified `NON_ALPHANUM_PATTERN` to allow dots: `/[^a-z0-9\.]+/`

didn't need to modify the `extract_safe_name` method itself because the changes to `NON_ALPHANUM_PATTERN` are sufficient to preserve dots. ( I think)

